### PR TITLE
Add UIKit import to compile on Xcode 15

### DIFF
--- a/Sources/Highlighter/Highlighter.swift
+++ b/Sources/Highlighter/Highlighter.swift
@@ -12,6 +12,8 @@ import JavaScriptCore
 
 #if os(OSX)
 import AppKit
+#else
+import UIKit
 #endif
 
 


### PR DESCRIPTION
I needed to add an import UIKit in order to compile on Xcode 15. Otherwise there was an error saying NSParagraphStyle not found.