### PR TITLE
Make missing-style Debug warning opt-in to avoid regressing debug build perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Release Notes
 
+- 3.1.1 *19 June 2026*
+    - Make the “missing style” Debug warning opt-in via `Theme.logsMissingStyles` (default `false`). Unstyled classes are normal theming behaviour, so the per-token `print()` is no longer emitted by default, avoiding console spam and a Debug-build performance hit ([#8](https://github.com/smittytone/HighlighterSwift/issues/8)).
 - 3.1.0 *27 May 2026*
     - Bring all existing themes (styles) up to date with latest `highlight.js` versions.
     - Add `highlight.js` themes not yet included in *HighlighterSwift*.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HighlighterSwift 3.1.0
+# HighlighterSwift 3.1.1
 
 This library provides a Swift wrapper for the popular [Highlight.js](https://highlightjs.org/) code highlighting utility.
 
@@ -82,6 +82,16 @@ A value of `0.0` for `lineSpacing` is equivalent to single spacing. `paraSpacing
 Both values must be non-negative. Negative values be replaced with the default values.
 
 **Note** As shown above, these new values are applied to the `Highlighter` instance’s `theme` property.
+
+### Logging Missing Styles
+
+Some *Highlight.js* classes are intentionally left unstyled by a theme — for example, `hljs-operator` inherits the default colour under `atom-one-light` and `atom-one-dark`. By default **HighlighterSwift** ignores these silently. If you are debugging a custom theme and want to see which token classes have no matching style, set:
+
+```swift
+highlighter.theme.logsMissingStyles = true
+```
+
+This emits a `WARNING MISSING STYLE…` message per unstyled token, and only in `DEBUG` builds. It is `false` by default because unstyled classes are normal theming behaviour, and logging every one of them produces considerable console noise and slows down Debug-mode highlighting.
 
 You can set or change your preferred font later by using `setCodeFont()`, which takes an *NSFont* or *UIFont* instance configured for the font and text size you want, and is called on the *Highlighter* instance’s `theme` property:
 

--- a/Sources/Highlighter/Theme.swift
+++ b/Sources/Highlighter/Theme.swift
@@ -39,6 +39,12 @@ public class Theme {
     public var fontSize: CGFloat = 18.0
     // FROM 3.1.0
     public var name: String = ""
+    // FROM 3.1.1
+    // Opt-in logging of tokens whose style class is absent from the theme.
+    // Unstyled classes (eg. `hljs-operator` under `atom-one-*`) are normal
+    // theming behaviour, not errors, so this is off by default to avoid
+    // console spam and the associated Debug-build performance hit.
+    public var logsMissingStyles: Bool = false
 
 
     // MARK: - Private Properties
@@ -204,7 +210,7 @@ public class Theme {
 
                         attrs.updateValue(attrValue, forKey: attrName)
                     }
-                } else {
+                } else if self.logsMissingStyles {
 #if DEBUG
                     print("WARNING MISSING STYLE in \(self.name): \(aStyle)")
 #endif


### PR DESCRIPTION
## Summary

`Theme.applyStyleToString()` emitted a `#if DEBUG` `print()` for **every** token whose style class is absent from the theme. Unstyled classes are normal theming behaviour — e.g. `hljs-operator` intentionally inherits the default colour under `atom-one-light`/`atom-one-dark` — so this fired thousands of times per highlighting pass (~5,585 prints / ~167ms in the reported case), spamming the console and noticeably degrading Debug-mode highlighting performance.

This implements: gate the warning behind an opt-in flag rather than removing it, so the diagnostic is still available when developing a custom theme.

## Changes

- Add `public var logsMissingStyles: Bool = false` to `Theme`.
- Only emit the `WARNING MISSING STYLE…` print when `logsMissingStyles` is `true` (still `#if DEBUG`-gated, so Release builds are unchanged).
- Document the flag in the README and add a usage example.
- Add a CHANGELOG entry and bump the version to 3.1.1.

## Usage

```swift
highlighter.theme.logsMissingStyles = true   // off by default
```

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)